### PR TITLE
Refactor string plan modifier in Terraform provider.

### DIFF
--- a/util/plan_modifier.go
+++ b/util/plan_modifier.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 )
 
 func ReplaceIfInt64Diff() planmodifier.Int64 {
@@ -15,10 +14,27 @@ func ReplaceIfInt64Diff() planmodifier.Int64 {
 		"If the value of this attribute changes, Terraform will destroy and recreate the resource.")
 }
 
-func ReplaceIfStringDiff() planmodifier.String {
-	return stringplanmodifier.RequiresReplaceIf(func(ctx context.Context, request planmodifier.StringRequest, response *stringplanmodifier.RequiresReplaceIfFuncResponse) {
+type replaceIfStringDiff struct {
+}
+
+func (r replaceIfStringDiff) Description(ctx context.Context) string {
+	return "If the value of this attribute changes, Terraform will destroy and recreate the resource."
+}
+
+func (r replaceIfStringDiff) MarkdownDescription(ctx context.Context) string {
+	return "If the value of this attribute changes, Terraform will destroy and recreate the resource."
+}
+
+func (r replaceIfStringDiff) PlanModifyString(ctx context.Context, request planmodifier.StringRequest, response *planmodifier.StringResponse) {
+	if request.PlanValue.IsUnknown() || request.PlanValue.IsNull() {
+		response.RequiresReplace = false
+	} else {
 		response.RequiresReplace = !request.PlanValue.Equal(request.StateValue)
-	},
-		"If the value of this attribute changes, Terraform will destroy and recreate the resource.",
-		"If the value of this attribute changes, Terraform will destroy and recreate the resource.")
+	}
+}
+
+var _ planmodifier.String = &replaceIfStringDiff{}
+
+func ReplaceIfStringDiff() planmodifier.String {
+	return &replaceIfStringDiff{}
 }


### PR DESCRIPTION
Replaced the function ReplaceIfStringDiff() with a struct equivalent in plan_modifier.go. This new struct-based approach allows more detailed control over the attribute changes, ensuring appropriate actions (like resource recreation) are triggered when needed. The logic of "RequiresReplace" is also improved to handle unknown and null plan values.